### PR TITLE
Binder files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # jupyterlab-debugger
 
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/QuantStack/jupyterlab-debugger/master?urlpath=/lab)
+
 Debugger extension for JupyterLab.
 
 ## Prerequisites

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,0 +1,1 @@
+net-tools

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,9 @@
+name: jupyterlab-debugger
+channels:
+- conda-forge
+dependencies:
+- nodejs
+- ptvsd
+- xeus-python=0.4
+- pip:
+  - jupyterlab==1.1.0a1

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,6 +3,7 @@ channels:
 - conda-forge
 dependencies:
 - nodejs
+- notebook=6
 - ptvsd
 - xeus-python=0.4
 - pip:

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,3 @@
+mkdir xpython_debug_logs
+
+jlpm && jlpm build && jupyter labextension install .

--- a/binder/start
+++ b/binder/start
@@ -1,1 +1,0 @@
-export XEUS_LOG=1

--- a/binder/start
+++ b/binder/start
@@ -1,0 +1,1 @@
+export XEUS_LOG=1


### PR DESCRIPTION
Add Binder files so we can actually try this demo on Binder directly.

When creating the `environment.yml` file, we need to make sure to use `notebook=6`, otherwise the default notebook will be used (5.7 at the moment), which does not contain https://github.com/jupyter/jupyter_client/pull/447.

Also adding `net-tools` for troubleshooting purposes.