### PR TITLE
Add example notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jupyterlab-debugger
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/QuantStack/jupyterlab-debugger/master?urlpath=/lab)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/QuantStack/jupyterlab-debugger/master?urlpath=/lab/tree/examples/demo.ipynb)
 
 Debugger extension for JupyterLab.
 

--- a/examples/demo.ipynb
+++ b/examples/demo.ipynb
@@ -1,0 +1,31 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(5):\n",
+    "    j = i + 1\n",
+    "    k = j ** 2\n",
+    "    print(i, j, k)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "xpython",
+   "language": "python",
+   "name": "xpython"
+  },
+  "language_info": {
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
- Add an example notebook with `xeus-python` as kernelspec
- Open this example automatically with Binder